### PR TITLE
Increase KV cache TTL to reduce API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 test-api
+=============
+
+This project exposes a small Cloudflare Worker used for testing. The worker
+increments a counter stored in Workers KV.
+
+To avoid exhausting the Workers KV daily free tier:
+
+* The counter is fetched with a `cacheTtl` of 600 seconds (10 minutes). Cloudflare
+  requires a minimum of 60 seconds, and a longer TTL reduces the number of reads
+  against KV.
+* Monitor KV usage in the Cloudflare dashboard and adjust the TTL if traffic
+  grows.
+* Consider batching writes or adding additional in-memory caching to further
+  reduce KV operations.
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,14 @@ interface Env {
 }
 
 const COUNTER_KEY = "counter";
+const COUNTER_CACHE_TTL = 600; // Cloudflare requires >=60s; use 10 minutes to reduce KV reads
 
 async function incrementCounter(env: Env): Promise<number> {
-  // Use a cacheTtl of 0 to avoid stale reads from the edge cache.
-  // Without this, KV can return an outdated value for up to 60 seconds,
-  // causing the counter to unexpectedly reset.
+  // Use a cacheTtl to reduce KV API usage while keeping reads reasonably fresh.
+  // A higher TTL helps stay within the free tier limits at the cost of stale values.
   const current = parseInt(
-    (await env.COUNTER.get(COUNTER_KEY, { cacheTtl: 60 })) ?? "60",
+    (await env.COUNTER.get(COUNTER_KEY, { cacheTtl: COUNTER_CACHE_TTL })) ??
+      "0",
     10,
   );
   const next = current + 1;


### PR DESCRIPTION
## Summary
- raise KV cache TTL to 600 seconds to lower daily request volume
- document KV usage limits and mitigation steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c45f5b0eb083299dcaa48b162de59e